### PR TITLE
Kong OAuth2.0 Plugin Integration + Unit Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ cf ssh -N -T -L 8081:localhost:8081 give-api-gateway
 _8081 is set as the Admin API port in [manifest.yml](manifest.yml), along with 8080 as the proxy port. This is due to Cloud Foundry restricting 8080 as the default port_
 
 
+### OAuth 2.0 Authorization
+
+The GIVE API Gateway is deployed with a Kong OAuth 2.0 authorization plugin with Client Credentials Grant enabled. All requests must follow the [Client Credentials Grant Flow](https://tools.ietf.org/html/rfc6749#section-4.4).
+
 ### Troubleshooting
 
 Since this is not a compiled application, there isn't any debugging involved. You can set the [log level](https://docs.konghq.com/2.1.x/logging/) in the [manifest.yml](/manifest.yml) file and the view the logs in the Cloud.gov application dashboard under **Log Stream**.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,13 @@
+#!/bin/bash
+
+# Pseudo deployment executable
+# Deploys app to cloud.gov with cloud foundry 
+
+# dependency phase
 python3.9 -m pip install -r tests/requirements.txt
 
+# deployment phase
 cf push --vars-file vars.yml
 
+# post reployment phase
 ./post-deployment.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,5 @@
-#python3.9 -m pip install -r tests/requirements.txt
+python3.9 -m pip install -r tests/requirements.txt
 
 cf push --vars-file vars.yml
-#./post-deployment.sh
+
+./post-deployment.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-python3.9 -m pip install -r tests/requirements.txt
+#python3.9 -m pip install -r tests/requirements.txt
 
 cf push --vars-file vars.yml
-./post-deployment.sh
+#./post-deployment.sh

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,3 +23,4 @@ applications:
     KONG_ADMIN_ACCESS_LOG: /dev/stdout
     KONG_PROXY_ERROR_LOG: /dev/stderr
     KONG_ADMIN_ERROR_LOG: /dev/stderr
+    KONG_TRUSTED_IPS: 0.0.0.0/0

--- a/post-deployment.sh
+++ b/post-deployment.sh
@@ -19,5 +19,5 @@ curl -X POST http://localhost:8081/services/auth-service/plugins/ \
     --data "config.enable_authorization_code=true" \
     --data "config.global_credentials=true" \
     --data "config.accept_http_if_already_terminated=true"
-#pytest tests/test_kong.py
+pytest tests/test_kong.py
 kill $PID

--- a/post-deployment.sh
+++ b/post-deployment.sh
@@ -3,6 +3,21 @@ echo 'post deployment script'
 cf ssh -N -T -L 8081:localhost:8081 give-api-gateway &
 PID=$!
 sleep 3
-curl -X POST http://localhost:8081/plugins/ --data "name=key-auth"
-pytest tests/test_kong.py
+curl -X POST \
+    --url "localhost:8081/services" \
+    --data "name=auth-service" \
+    --data "url=https://konghq.com/"
+curl -i -X POST \
+    --url http://localhost:8081/services/auth-service/routes \
+    --data 'paths[]=/auth' \
+    --data 'methods[]=GET&methods[]=POST'
+curl -X POST http://localhost:8081/services/auth-service/plugins/ \
+    --data "name=oauth2"  \
+    --data "config.scopes=rpname" \
+    --data "config.mandatory_scope=true" \
+    --data "config.enable_client_credentials=true" \
+    --data "config.enable_authorization_code=true" \
+    --data "config.global_credentials=true" \
+    --data "config.accept_http_if_already_terminated=true"
+#pytest tests/test_kong.py
 kill $PID

--- a/post-deployment.sh
+++ b/post-deployment.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
-echo 'post deployment script'
+
+# Post Deployment Kong API Gateway Setup
+# Deploys plugins, services, and routes
+# Runs unit tests 
+
+# setup ssh tunnel to Kong Admin API
 cf ssh -N -T -L 8081:localhost:8081 give-api-gateway &
 PID=$!
 sleep 3
+
+# add auth service
 curl -X POST \
     --url "localhost:8081/services" \
     --data "name=auth-service" \
     --data "url=https://konghq.com/"
+
+# add routes to auth service
 curl -i -X POST \
     --url http://localhost:8081/services/auth-service/routes \
     --data 'paths[]=/auth' \
     --data 'methods[]=GET&methods[]=POST'
+
+# add oauth plugin to service
 curl -X POST http://localhost:8081/services/auth-service/plugins/ \
     --data "name=oauth2"  \
     --data "config.scopes=rpname" \
@@ -19,5 +30,7 @@ curl -X POST http://localhost:8081/services/auth-service/plugins/ \
     --data "config.enable_authorization_code=true" \
     --data "config.global_credentials=true" \
     --data "config.accept_http_if_already_terminated=true"
+
+# run unit tests
 pytest tests/test_kong.py
 kill $PID

--- a/tests/test_kong.py
+++ b/tests/test_kong.py
@@ -5,14 +5,32 @@ def test_get_kong_check_status_code():
     response = requests.get("http://localhost:8081")
     assert response.status_code == 200
 
-def test_get_kong_plugins_verify_hmac():
-    response = requests.get("http://localhost:8081/plugins")
+def test_get_kong_plugins_verify_oauth():
+    response = requests.get("http://localhost:8081/plugins/")
     body_dictionary = json.loads(response.text)
 
-    plugin_data = body_dictionary["data"]
+    data = body_dictionary["data"]
 
-    for x in range(len(plugin_data)):
-        if plugin_data[x]["name"] == "key-auth":
+    for x in range(len(data)):
+        plugin = data[x]
+        if plugin["name"] == "oauth2":
+            config = plugin["config"]
+            if config["enable_client_credentials"] == True and config["enable_authorization_code"] == True and config["global_credentials"] == True:
+                assert True
+                return
+            assert False
+    assert False
+
+def test_get_kong_service_verify_auth_service():
+    response = requests.get("http://localhost:8081/services/")
+    body_dictionary = json.loads(response.text)
+
+    data = body_dictionary["data"]
+
+    for x in range(len(data)):
+        service = data[x]
+        if service["name"] == "auth-service":
             assert True
             return
+
     assert False


### PR DESCRIPTION
Deploy Kong API Gateway with OAuth2.0 authorization plugin enabled. Add empty authorization service that handles authorization/token requests for generating the credentials for authenticated users. Add unit tests to ensure the plugin/service were properly setup.