### PR TITLE
Update idemia config to be private

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -26,6 +26,10 @@ jobs:
           cf auth ${{ secrets.CF_USERNAME }} ${{ secrets.CF_PASSWORD }}
           cf target -o ${{ secrets.CF_ORG }} -s give-dev
 
+      - name: Apply CF Network Policies
+        run: |
+          cf add-network-policy give-api-gateway ipp-idemia
+
       - name: Deploy application
         run: |
           cf push --vars-file vars.yaml

--- a/kong.yaml
+++ b/kong.yaml
@@ -2,7 +2,7 @@
 _format_version: "1.1"
 services:
   - connect_timeout: 60000
-    url: https://identity-give-ipp.app.cloud.gov:443
+    url: http://identity-give-ipp.app.cloud.gov:8080
     name: idemia-microservice
     read_timeout: 60000
     retries: 5
@@ -18,7 +18,6 @@ services:
         path_handling: v0
         preserve_host: false
         protocols:
-          - https
           - http
         regex_priority: 0
         strip_path: true


### PR DESCRIPTION
Change the kong configuration to support a private cloud foundry
application and change the deployment process to ensure the network
policy is always in place to allow traffic between the applications.