### PR TITLE
Add trigger filter on pull requests

### DIFF
--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -8,6 +8,12 @@ on:
     branches:
       - main
   pull_request:
+    # Only run the config validation if the config file has changed in a pull
+    # requests. Don't add this to the push->branches->main section, as we still
+    # want pushes to the main branch to trigger a deployment whether the config
+    # changed or not.
+    paths:
+      - 'kong.yaml'
 
 jobs:
   deploy:

--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -9,7 +9,7 @@ on:
       - main
   pull_request:
     # Only run the config validation if the config file has changed in a pull
-    # requests. Don't add this to the push->branches->main section, as we still
+    # request. Don't add this to the push->branches->main section, as we still
     # want pushes to the main branch to trigger a deployment whether the config
     # changed or not.
     paths:


### PR DESCRIPTION
Only trigger the validate-config workflow on pull requests when it's
needed to validate that a change doesn't break the config. Otherwise, we
want all pushes to the main branch to trigger config validation as this
workflow's success is the trigger for a deployment.