### PR TITLE
Feature/workflow order update

### DIFF
--- a/.github/workflows/validate-config.yaml
+++ b/.github/workflows/validate-config.yaml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'  # All markdown files in the repository
   pull_request:
     # Only run the config validation if the config file has changed in a pull
     # request. Don't add this to the push->branches->main section, as we still

--- a/.github/workflows/zap-pen-test.yaml
+++ b/.github/workflows/zap-pen-test.yaml
@@ -1,12 +1,13 @@
 ---
 # This workflow will run a series of penetration tests against the GIVE API Gateway
 
+name: Zap-Pen-Test
+
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'  # All markdown files in the repository
+  workflow_run:
+    workflows: ["Deploy-Dev"]
+    branches: [main]
+    types: [completed]
 
 jobs:
   zap_scan:

--- a/.github/workflows/zap-scan.yaml
+++ b/.github/workflows/zap-scan.yaml
@@ -1,7 +1,7 @@
 ---
 # This workflow will run a series of penetration tests against the GIVE API Gateway
 
-name: Zap-Pen-Test
+name: Zap-Scan
 
 on:
   workflow_run:


### PR DESCRIPTION
Re-order the github actions so that the ZAP pen test only runs after a successful deploy. Configure the Config Validation action to ignore markdown files.